### PR TITLE
Introduce install and uninstall targets to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,12 @@ VERSION ?= Linux_Musl
 OS = linux
 ARCH ?= X86_64
 
+# Installation settings
+PREFIX ?= /usr/local
+LIBDIR ?= $(PREFIX)/lib
+INCLUDEDIR ?= $(PREFIX)/include
+DESTDIR ?=
+
 # Cross-compiler tools (automatically set for AArch64)
 .if ${ARCH} == aarch64
 AS := aarch64-linux-gnu-as
@@ -61,7 +67,7 @@ test: default crt0.o
 	$(LD) -o tests.exe -static crt0.o stdio/printf.o string.o prng/rand.o stdarg.o exit/assert.o string/memcpy.o object.o posix/sys/writev.o tests/*.o #-macosx_version_min 10.7.0
 	./tests.exe
 
-.PHONY: all test clean
+.PHONY: all test clean install uninstall
 
 all: libbutterc.so
 
@@ -70,3 +76,13 @@ clean:
 	rm *.o */*.o */*/*.o || true
 	rm *.dylib || true
 	rm libbutterc.so || true
+
+install: libbutterc.so
+	mkdir -p "$(DESTDIR)$(LIBDIR)"
+	cp libbutterc.so "$(DESTDIR)$(LIBDIR)/"
+	@echo "Installed libbutterc.so to $(DESTDIR)$(LIBDIR)/"
+	@echo "Note: System-wide installation to /usr/local may require sudo"
+
+uninstall:
+	rm -f "$(DESTDIR)$(LIBDIR)/libbutterc.so"
+	@echo "Uninstalled libbutterc.so from $(DESTDIR)$(LIBDIR)/"

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,6 @@ ARCH ?= X86_64
 # Installation settings
 PREFIX ?= /usr/local
 LIBDIR ?= $(PREFIX)/lib
-INCLUDEDIR ?= $(PREFIX)/include
 DESTDIR ?=
 
 # Cross-compiler tools (automatically set for AArch64)

--- a/Makefile
+++ b/Makefile
@@ -77,8 +77,8 @@ clean:
 	rm libbutterc.so || true
 
 install: libbutterc.so
-	mkdir -p "$(DESTDIR)$(LIBDIR)"
-	cp libbutterc.so "$(DESTDIR)$(LIBDIR)/"
+	install -d "$(DESTDIR)$(LIBDIR)"
+	install -m 755 libbutterc.so "$(DESTDIR)$(LIBDIR)/"
 	@echo "Installed libbutterc.so to $(DESTDIR)$(LIBDIR)/"
 	@echo "Note: System-wide installation to /usr/local may require sudo"
 

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ clean:
 
 install: libbutterc.so
 	install -d "$(DESTDIR)$(LIBDIR)"
-	install -m 755 libbutterc.so "$(DESTDIR)$(LIBDIR)/"
+	install -m 644 libbutterc.so "$(DESTDIR)$(LIBDIR)/"
 	@echo "Installed libbutterc.so to $(DESTDIR)$(LIBDIR)/"
 	@echo "Note: System-wide installation to /usr/local may require sudo"
 


### PR DESCRIPTION
This PR introduces proper installation support to the butterlibc Makefile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added standard install and uninstall commands to the build system to manage the library.
  * Installation supports configurable target paths and staged installs for packaging.
  * Uninstall removes installed library files and reports status during operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->