### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/cirnatdan/butterlibc/security/code-scanning/1](https://github.com/cirnatdan/butterlibc/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root so all jobs (currently just `build`) get least-privilege token scopes by default.  
For this workflow, the minimal required permission is:

- `contents: read` (needed by `actions/checkout`)

Best fix without changing functionality:
- Edit `.github/workflows/build.yml`
- Insert a root-level `permissions:` block between `on:` and `jobs:` (or directly after `name:` / event config), with:
  - `contents: read`

No imports, methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build workflow security by restricting permissions to minimum required access levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->